### PR TITLE
fix quando energias estao vazias no coeficiente

### DIFF
--- a/api/utils.py
+++ b/api/utils.py
@@ -122,7 +122,10 @@ def import_all_data():
 
 
 def get_coefficient(x, y):
-    return stats.linregress(x, y)[0]
+    if(x and y):
+        return stats.linregress(x, y)[0]
+    else:
+        return 0
 
 
 def datetime_to_timestamp(date):


### PR DESCRIPTION
Endpoint de exemplo: `/energia/camara/2170839?semanas_anteriores=12&data_referencia=2015-11-09` 

Em algumas datas não vai existir energia, e o cálculo do coeficiente estava sempre esperando que exista, então estava retornando o erro **Inputs must not be empty.**